### PR TITLE
Use /import as temp directory for import

### DIFF
--- a/musicbrainz/src/install.sh
+++ b/musicbrainz/src/install.sh
@@ -183,7 +183,7 @@ wget -r --no-parent -nd -nH -P /import --reject "index.html*, mbdump-edit.*, mbd
 pushd /import && md5sum -c MD5SUMS && popd
 chown -R nobody:users /import
 cd /opt/musicbrainz
-./admin/InitDb.pl --createdb --import /import/mbdump*.tar.bz2 --echo
+./admin/InitDb.pl --createdb --import /import/mbdump*.tar.bz2 --tmp-dir /import --echo
 echo "IMPORT IS COMPLETE, MOVING TO NEXT PHASE"
 fi
 EOT


### PR DESCRIPTION
- use /import instead of the default /tmp for import temp extraction directory.  Without this my docker image file ballooned and ran out of space (Currently using a 10GB Docker image that was about 30% full before running this container)

The /import folder will grow to about 10GB total containing the bz2 dump files and the extracted temp folders while the import step is executing but afterwards will automatically clean up these temp sub-directories and reduce it back down to just the bz2 files (~2GB).
